### PR TITLE
bump leveldown-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "main": "level.js",
   "dependencies": {
-    "leveldown-prebuilt": "0.10.2",
+    "leveldown-prebuilt": "~1.0.3",
     "level-packager": "~0.18.0"
   },
   "devDependencies": {


### PR DESCRIPTION
this allows for node 0.12 / io support \o/